### PR TITLE
Fixed infinite unique location identification loop in `generateItinerary`

### DIFF
--- a/api.py
+++ b/api.py
@@ -340,6 +340,9 @@ def generateItinerary():
         return "ERROR: One or more required payload parameters not present."
     if "description" not in request.json:
         return "ERROR: One or more required payload parameters not present."
+    
+    if len(Universal.generationData) == 0 or 'locations' not in Universal.generationData or len(Universal.generationData['locations']) == 0:
+        return "UERROR: Generation data not available. Please try again later."
 
     cleanTargetLocations = [x for x in request.json['targetLocations'] if x in Universal.generationData['locations']]
     if len(cleanTargetLocations) > 9:

--- a/api.py
+++ b/api.py
@@ -372,12 +372,25 @@ def generateItinerary():
 
     ## Prepare locations list
     locations = cleanTargetLocations
+    duplicatesInsertedAsContingency = 0
     while len(locations) < 9:
-        randomIndex = random.randint(0, len(locations) - 1)
+        randomIndex = random.randint(0, len(locations) - 1) if len(locations) > 0 else 0
         randomLocation = None
-        while randomLocation == None or randomLocation in locations:
+        attempts = 30
+        while (randomLocation == None or randomLocation in locations) and attempts > 0:
             randomLocation = random.choice([name for name in Universal.generationData["locations"]])
+            attempts -= 1
+        
+        ## If a unique new location really cannot be found, insert a random location, regardless of duplicates
+        if randomLocation == None or attempts <= 0:
+            locations.insert(randomIndex, random.choice([name for name in Universal.generationData["locations"]]))
+            duplicatesInsertedAsContingency += 1
+            continue
+
         locations.insert(randomIndex, randomLocation)
+    
+    if duplicatesInsertedAsContingency > 0:
+        Logger.log("API GENERATEITINERARY WARNING: {} duplicate locations inserted as contingency as enough new unique locations could not be found to insert.".format(duplicatesInsertedAsContingency))
     
     activities = [tuple(locations[i:i+3]) for i in range(0, len(locations), 3)]
 

--- a/models.py
+++ b/models.py
@@ -354,7 +354,12 @@ class Universal:
     def loadGenerationData(returnValue=False):
         if os.path.isfile(os.path.join(os.getcwd(), Universal.generationDataFilename)):
             with open(Universal.generationDataFilename, "r") as f:
-                Universal.generationData = json.load(f)
+                try:
+                    Universal.generationData = json.load(f)
+                except Exception as e:
+                    print("UNIVERSAL LOADGENERATIONDATA WARNING: Failed to load generation data. Error: {}".format(e))
+                    Universal.generationData = {}
+                
                 return Universal.generationData if returnValue else None
         else:
             Universal.generationData = {}


### PR DESCRIPTION
Fixed a bug where, if `generationData.json` has less than 9 locations, the generation algorithm would loop infinitely. The algorithm now limits the selection of a unique new location to 30 attempts, and inserts any location, regardless of whether it is a duplicate, as contingency.